### PR TITLE
Allow async nodes to be canceled by using a context

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,9 +11,7 @@
 				"EditorConfig.EditorConfig"
 			]
 		}
-	},
-
-	"mounts": ["type=bind,source=/dev/bus/usb,target=/dev/bus/usb"]
+	}
 
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	// "features": {},

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,7 +11,9 @@
 				"EditorConfig.EditorConfig"
 			]
 		}
-	}
+	},
+
+	"mounts": ["type=bind,source=/dev/bus/usb,target=/dev/bus/usb"]
 
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	// "features": {},

--- a/common/action/fail.go
+++ b/common/action/fail.go
@@ -21,7 +21,7 @@ type fail[Blackboard any] struct {
 func (a *fail[Blackboard]) Enter(bb Blackboard) {}
 
 // Tick ...
-func (a *fail[Blackboard]) Tick(bb Blackboard, ctx context.Context, evt core.Event) core.NodeResult {
+func (a *fail[Blackboard]) Tick(ctx context.Context, bb Blackboard, evt core.Event) core.NodeResult {
 	return core.StatusFailure
 }
 

--- a/common/action/fail.go
+++ b/common/action/fail.go
@@ -1,6 +1,8 @@
 package action
 
 import (
+	"context"
+
 	"github.com/jbcpollak/greenstalk/core"
 )
 
@@ -19,7 +21,7 @@ type fail[Blackboard any] struct {
 func (a *fail[Blackboard]) Enter(bb Blackboard) {}
 
 // Tick ...
-func (a *fail[Blackboard]) Tick(bb Blackboard, evt core.Event) core.NodeResult {
+func (a *fail[Blackboard]) Tick(bb Blackboard, ctx context.Context, evt core.Event) core.NodeResult {
 	return core.StatusFailure
 }
 

--- a/common/action/succeed.go
+++ b/common/action/succeed.go
@@ -21,7 +21,7 @@ type succeed[Blackboard any] struct {
 func (a *succeed[Blackboard]) Enter(bb Blackboard) {}
 
 // Tick ...
-func (a *succeed[Blackboard]) Tick(bb Blackboard, ctx context.Context, evt core.Event) core.NodeResult {
+func (a *succeed[Blackboard]) Tick(ctx context.Context, bb Blackboard, evt core.Event) core.NodeResult {
 	return core.StatusSuccess
 }
 

--- a/common/action/succeed.go
+++ b/common/action/succeed.go
@@ -1,6 +1,8 @@
 package action
 
 import (
+	"context"
+
 	"github.com/jbcpollak/greenstalk/core"
 )
 
@@ -19,7 +21,7 @@ type succeed[Blackboard any] struct {
 func (a *succeed[Blackboard]) Enter(bb Blackboard) {}
 
 // Tick ...
-func (a *succeed[Blackboard]) Tick(bb Blackboard, evt core.Event) core.NodeResult {
+func (a *succeed[Blackboard]) Tick(bb Blackboard, ctx context.Context, evt core.Event) core.NodeResult {
 	return core.StatusSuccess
 }
 

--- a/common/composite/active_sequence.go
+++ b/common/composite/active_sequence.go
@@ -20,9 +20,9 @@ type activeSequence[Blackboard any] struct {
 
 func (s *activeSequence[Blackboard]) Enter(bb Blackboard) {}
 
-func (s *activeSequence[Blackboard]) Tick(bb Blackboard, ctx context.Context, evt core.Event) core.NodeResult {
+func (s *activeSequence[Blackboard]) Tick(ctx context.Context, bb Blackboard, evt core.Event) core.NodeResult {
 	for i := 0; i < len(s.Children); i++ {
-		result := core.Update(s.Children[i], bb, ctx, evt)
+		result := core.Update(ctx, s.Children[i], bb, evt)
 		if result.Status() != core.StatusSuccess {
 			return result
 		}

--- a/common/composite/active_sequence.go
+++ b/common/composite/active_sequence.go
@@ -1,6 +1,8 @@
 package composite
 
 import (
+	"context"
+
 	"github.com/jbcpollak/greenstalk/core"
 )
 
@@ -18,9 +20,9 @@ type activeSequence[Blackboard any] struct {
 
 func (s *activeSequence[Blackboard]) Enter(bb Blackboard) {}
 
-func (s *activeSequence[Blackboard]) Tick(bb Blackboard, evt core.Event) core.NodeResult {
+func (s *activeSequence[Blackboard]) Tick(bb Blackboard, ctx context.Context, evt core.Event) core.NodeResult {
 	for i := 0; i < len(s.Children); i++ {
-		result := core.Update(s.Children[i], bb, evt)
+		result := core.Update(s.Children[i], bb, ctx, evt)
 		if result.Status() != core.StatusSuccess {
 			return result
 		}

--- a/common/composite/parallel.go
+++ b/common/composite/parallel.go
@@ -44,7 +44,7 @@ func (s *parallel[Blackboard]) Enter(bb Blackboard) {
 	s.fail = 0
 }
 
-func (s *parallel[Blackboard]) Tick(bb Blackboard, ctx context.Context, evt core.Event) core.NodeResult {
+func (s *parallel[Blackboard]) Tick(ctx context.Context, bb Blackboard, evt core.Event) core.NodeResult {
 
 	// Update every child that has not completed yet every tick.
 	for i := 0; i < len(s.Children); i++ {
@@ -56,7 +56,7 @@ func (s *parallel[Blackboard]) Tick(bb Blackboard, ctx context.Context, evt core
 
 		// Update a child and count whether it succeeded or failed,
 		// and mark it as completed in either of those two cases.
-		switch core.Update(s.Children[i], bb, ctx, evt) {
+		switch core.Update(ctx, s.Children[i], bb, evt) {
 		case core.StatusSuccess:
 			s.succ++
 			s.completed[i] = true

--- a/common/composite/parallel.go
+++ b/common/composite/parallel.go
@@ -1,6 +1,8 @@
 package composite
 
 import (
+	"context"
+
 	"github.com/jbcpollak/greenstalk/core"
 )
 
@@ -42,7 +44,7 @@ func (s *parallel[Blackboard]) Enter(bb Blackboard) {
 	s.fail = 0
 }
 
-func (s *parallel[Blackboard]) Tick(bb Blackboard, evt core.Event) core.NodeResult {
+func (s *parallel[Blackboard]) Tick(bb Blackboard, ctx context.Context, evt core.Event) core.NodeResult {
 
 	// Update every child that has not completed yet every tick.
 	for i := 0; i < len(s.Children); i++ {
@@ -54,7 +56,7 @@ func (s *parallel[Blackboard]) Tick(bb Blackboard, evt core.Event) core.NodeResu
 
 		// Update a child and count whether it succeeded or failed,
 		// and mark it as completed in either of those two cases.
-		switch core.Update(s.Children[i], bb, evt) {
+		switch core.Update(s.Children[i], bb, ctx, evt) {
 		case core.StatusSuccess:
 			s.succ++
 			s.completed[i] = true

--- a/common/composite/persistent_sequence.go
+++ b/common/composite/persistent_sequence.go
@@ -20,9 +20,9 @@ type persistentSequence[Blackboard any] struct {
 
 func (s *persistentSequence[Blackboard]) Enter(bb Blackboard) {}
 
-func (s *persistentSequence[Blackboard]) Tick(bb Blackboard, ctx context.Context, evt core.Event) core.NodeResult {
+func (s *persistentSequence[Blackboard]) Tick(ctx context.Context, bb Blackboard, evt core.Event) core.NodeResult {
 	for s.CurrentChild < len(s.Children) {
-		result := core.Update(s.Children[s.CurrentChild], bb, ctx, evt)
+		result := core.Update(ctx, s.Children[s.CurrentChild], bb, evt)
 		if result.Status() != core.StatusSuccess {
 			return result
 		}

--- a/common/composite/persistent_sequence.go
+++ b/common/composite/persistent_sequence.go
@@ -1,6 +1,8 @@
 package composite
 
 import (
+	"context"
+
 	"github.com/jbcpollak/greenstalk/core"
 )
 
@@ -18,9 +20,9 @@ type persistentSequence[Blackboard any] struct {
 
 func (s *persistentSequence[Blackboard]) Enter(bb Blackboard) {}
 
-func (s *persistentSequence[Blackboard]) Tick(bb Blackboard, evt core.Event) core.NodeResult {
+func (s *persistentSequence[Blackboard]) Tick(bb Blackboard, ctx context.Context, evt core.Event) core.NodeResult {
 	for s.CurrentChild < len(s.Children) {
-		result := core.Update(s.Children[s.CurrentChild], bb, evt)
+		result := core.Update(s.Children[s.CurrentChild], bb, ctx, evt)
 		if result.Status() != core.StatusSuccess {
 			return result
 		}

--- a/common/composite/random_selector.go
+++ b/common/composite/random_selector.go
@@ -3,7 +3,6 @@ package composite
 import (
 	"context"
 	"math/rand"
-	"time"
 
 	"github.com/jbcpollak/greenstalk/core"
 )
@@ -23,11 +22,10 @@ type randomSelector[Blackboard any] struct {
 func (s *randomSelector[Blackboard]) Enter(bb Blackboard) {}
 
 // Tick ...
-func (s *randomSelector[Blackboard]) Tick(bb Blackboard, ctx context.Context, evt core.Event) core.NodeResult {
-	rand.Seed(time.Now().UnixNano())
+func (s *randomSelector[Blackboard]) Tick(ctx context.Context, bb Blackboard, evt core.Event) core.NodeResult {
 	index := rand.Intn(len(s.Children))
 	child := s.Children[index]
-	return core.Update(child, bb, ctx, evt)
+	return core.Update(ctx, child, bb, evt)
 }
 
 // Leave ...

--- a/common/composite/random_selector.go
+++ b/common/composite/random_selector.go
@@ -1,6 +1,7 @@
 package composite
 
 import (
+	"context"
 	"math/rand"
 	"time"
 
@@ -22,11 +23,11 @@ type randomSelector[Blackboard any] struct {
 func (s *randomSelector[Blackboard]) Enter(bb Blackboard) {}
 
 // Tick ...
-func (s *randomSelector[Blackboard]) Tick(bb Blackboard, evt core.Event) core.NodeResult {
+func (s *randomSelector[Blackboard]) Tick(bb Blackboard, ctx context.Context, evt core.Event) core.NodeResult {
 	rand.Seed(time.Now().UnixNano())
 	index := rand.Intn(len(s.Children))
 	child := s.Children[index]
-	return core.Update(child, bb, evt)
+	return core.Update(child, bb, ctx, evt)
 }
 
 // Leave ...

--- a/common/composite/random_sequence.go
+++ b/common/composite/random_sequence.go
@@ -1,6 +1,7 @@
 package composite
 
 import (
+	"context"
 	"math/rand"
 
 	"github.com/jbcpollak/greenstalk/core"
@@ -21,9 +22,9 @@ func (s *randomSequence[Blackboard]) Enter(bb Blackboard) {
 	shuffle(s.Children)
 }
 
-func (s *randomSequence[Blackboard]) Tick(bb Blackboard, evt core.Event) core.NodeResult {
+func (s *randomSequence[Blackboard]) Tick(bb Blackboard, ctx context.Context, evt core.Event) core.NodeResult {
 	for s.CurrentChild < len(s.Children) {
-		result := core.Update(s.Children[s.CurrentChild], bb, evt)
+		result := core.Update(s.Children[s.CurrentChild], bb, ctx, evt)
 		if result.Status() != core.StatusSuccess {
 			return result
 		}

--- a/common/composite/random_sequence.go
+++ b/common/composite/random_sequence.go
@@ -22,9 +22,9 @@ func (s *randomSequence[Blackboard]) Enter(bb Blackboard) {
 	shuffle(s.Children)
 }
 
-func (s *randomSequence[Blackboard]) Tick(bb Blackboard, ctx context.Context, evt core.Event) core.NodeResult {
+func (s *randomSequence[Blackboard]) Tick(ctx context.Context, bb Blackboard, evt core.Event) core.NodeResult {
 	for s.CurrentChild < len(s.Children) {
-		result := core.Update(s.Children[s.CurrentChild], bb, ctx, evt)
+		result := core.Update(ctx, s.Children[s.CurrentChild], bb, evt)
 		if result.Status() != core.StatusSuccess {
 			return result
 		}

--- a/common/composite/selector.go
+++ b/common/composite/selector.go
@@ -1,6 +1,8 @@
 package composite
 
 import (
+	"context"
+
 	"github.com/jbcpollak/greenstalk/core"
 )
 
@@ -20,9 +22,9 @@ func (s *selector[Blackboard]) Enter(bb Blackboard) {
 	s.Composite.CurrentChild = 0
 }
 
-func (s *selector[Blackboard]) Tick(bb Blackboard, evt core.Event) core.NodeResult {
+func (s *selector[Blackboard]) Tick(bb Blackboard, ctx context.Context, evt core.Event) core.NodeResult {
 	for s.CurrentChild < len(s.Children) {
-		status := core.Update(s.Children[s.CurrentChild], bb, evt)
+		status := core.Update(s.Children[s.CurrentChild], bb, ctx, evt)
 		if status != core.StatusFailure {
 			return status
 		}

--- a/common/composite/selector.go
+++ b/common/composite/selector.go
@@ -22,9 +22,9 @@ func (s *selector[Blackboard]) Enter(bb Blackboard) {
 	s.Composite.CurrentChild = 0
 }
 
-func (s *selector[Blackboard]) Tick(bb Blackboard, ctx context.Context, evt core.Event) core.NodeResult {
+func (s *selector[Blackboard]) Tick(ctx context.Context, bb Blackboard, evt core.Event) core.NodeResult {
 	for s.CurrentChild < len(s.Children) {
-		status := core.Update(s.Children[s.CurrentChild], bb, ctx, evt)
+		status := core.Update(ctx, s.Children[s.CurrentChild], bb, evt)
 		if status != core.StatusFailure {
 			return status
 		}

--- a/common/composite/sequence.go
+++ b/common/composite/sequence.go
@@ -22,9 +22,9 @@ func (s *sequence[Blackboard]) Enter(bb Blackboard) {
 	s.Composite.CurrentChild = 0
 }
 
-func (s *sequence[Blackboard]) Tick(bb Blackboard, ctx context.Context, evt core.Event) core.NodeResult {
+func (s *sequence[Blackboard]) Tick(ctx context.Context, bb Blackboard, evt core.Event) core.NodeResult {
 	for s.CurrentChild < len(s.Children) {
-		status := core.Update(s.Children[s.CurrentChild], bb, ctx, evt)
+		status := core.Update(ctx, s.Children[s.CurrentChild], bb, evt)
 		if status != core.StatusSuccess {
 			return status
 		}

--- a/common/composite/sequence.go
+++ b/common/composite/sequence.go
@@ -1,6 +1,8 @@
 package composite
 
 import (
+	"context"
+
 	"github.com/jbcpollak/greenstalk/core"
 )
 
@@ -20,9 +22,9 @@ func (s *sequence[Blackboard]) Enter(bb Blackboard) {
 	s.Composite.CurrentChild = 0
 }
 
-func (s *sequence[Blackboard]) Tick(bb Blackboard, evt core.Event) core.NodeResult {
+func (s *sequence[Blackboard]) Tick(bb Blackboard, ctx context.Context, evt core.Event) core.NodeResult {
 	for s.CurrentChild < len(s.Children) {
-		status := core.Update(s.Children[s.CurrentChild], bb, evt)
+		status := core.Update(s.Children[s.CurrentChild], bb, ctx, evt)
 		if status != core.StatusSuccess {
 			return status
 		}

--- a/common/decorator/asyncDelayer.go
+++ b/common/decorator/asyncDelayer.go
@@ -1,6 +1,7 @@
 package decorator
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -47,11 +48,11 @@ func (d *asyncdelayer[Blackboard]) doDelay(enqueue func(core.Event) error) error
 }
 
 // Tick ...
-func (d *asyncdelayer[Blackboard]) Tick(bb Blackboard, evt core.Event) core.NodeResult {
+func (d *asyncdelayer[Blackboard]) Tick(bb Blackboard, ctx context.Context, evt core.Event) core.NodeResult {
 
 	if _, ok := evt.(DelayerFinishedEvent); ok {
 		fmt.Printf("asyncdelayer: Calling child")
-		return core.Update(d.Child, bb, evt)
+		return core.Update(d.Child, bb, ctx, evt)
 	} else if d.Status() == core.StatusInitialized {
 		fmt.Printf("asyncdelayer: Returning AsyncRunning")
 

--- a/common/decorator/async_delayer.go
+++ b/common/decorator/async_delayer.go
@@ -30,7 +30,7 @@ func AsyncDelayer[Blackboard any](params core.Params, child core.Node[Blackboard
 
 	d := &asyncdelayer[Blackboard]{
 		Decorator: base,
-		delay:     time.Duration(delay),
+		delay:     delay,
 	}
 	return d
 }

--- a/common/decorator/async_delayer.go
+++ b/common/decorator/async_delayer.go
@@ -30,9 +30,8 @@ func AsyncDelayer[Blackboard any](params core.Params, child core.Node[Blackboard
 
 	d := &asyncdelayer[Blackboard]{
 		Decorator: base,
+		delay: time.Duration(delay),
 	}
-
-	d.delay = time.Duration(delay)
 	return d
 }
 

--- a/common/decorator/async_delayer.go
+++ b/common/decorator/async_delayer.go
@@ -61,10 +61,10 @@ func (e DelayerFinishedEvent) TargetNodeId() uuid.UUID {
 
 func (d *asyncdelayer[Blackboard]) doDelay(ctx context.Context, enqueue core.EnqueueFn) error {
 	t := time.NewTimer(d.delay)
+	defer t.Stop()
 	select {
 	case <-ctx.Done():
-		t.Stop()
-		return fmt.Errorf("Interrupted")
+		return fmt.Errorf("async delay interrupted: %w", ctx.Err())
 	case <-t.C:
 		log.Info().Msgf("Delayed: %v", time.Since(d.start))
 		return enqueue(DelayerFinishedEvent{d.Id(), d.start})

--- a/common/decorator/async_delayer.go
+++ b/common/decorator/async_delayer.go
@@ -30,7 +30,7 @@ func AsyncDelayer[Blackboard any](params core.Params, child core.Node[Blackboard
 
 	d := &asyncdelayer[Blackboard]{
 		Decorator: base,
-		delay: time.Duration(delay),
+		delay:     time.Duration(delay),
 	}
 	return d
 }
@@ -73,13 +73,13 @@ func (d *asyncdelayer[Blackboard]) doDelay(ctx context.Context, enqueue core.Enq
 }
 
 // Tick ...
-func (d *asyncdelayer[Blackboard]) Tick(bb Blackboard, ctx context.Context, evt core.Event) core.NodeResult {
+func (d *asyncdelayer[Blackboard]) Tick(ctx context.Context, bb Blackboard, evt core.Event) core.NodeResult {
 	log.Info().Msgf("%s: Tick", d.Name())
 
 	if dfe, ok := evt.(DelayerFinishedEvent); ok {
 		if dfe.TargetNodeId() == d.Id() {
 			log.Info().Msgf("%s: DelayerFinishedEvent", d.Name())
-			return core.Update(d.Child, bb, ctx, evt)
+			return core.Update(ctx, d.Child, bb, evt)
 		}
 	}
 

--- a/common/decorator/delayer.go
+++ b/common/decorator/delayer.go
@@ -1,6 +1,7 @@
 package decorator
 
 import (
+	"context"
 	"time"
 
 	"github.com/jbcpollak/greenstalk/core"
@@ -33,9 +34,9 @@ func (d *delayer[Blackboard]) Enter(bb Blackboard) {
 }
 
 // Tick ...
-func (d *delayer[Blackboard]) Tick(bb Blackboard, evt core.Event) core.NodeResult {
+func (d *delayer[Blackboard]) Tick(bb Blackboard, ctx context.Context, evt core.Event) core.NodeResult {
 	if time.Since(d.start) > d.delay {
-		return core.Update(d.Child, bb, evt)
+		return core.Update(d.Child, bb, ctx, evt)
 	}
 	return core.StatusRunning
 }

--- a/common/decorator/delayer.go
+++ b/common/decorator/delayer.go
@@ -2,6 +2,7 @@ package decorator
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/jbcpollak/greenstalk/core"
@@ -10,14 +11,20 @@ import (
 // Delayer ...
 func Delayer[Blackboard any](params core.Params, child core.Node[Blackboard]) core.Node[Blackboard] {
 	base := core.NewDecorator("Delayer", params, child)
-	d := &delayer[Blackboard]{Decorator: base}
 
-	delay, err := params.GetInt("delay")
+	v, err := params.Get("delay")
 	if err != nil {
 		panic(err)
 	}
+	delay, ok := v.(time.Duration)
+	if !ok {
+		panic(fmt.Errorf("delay must be a time.Duration"))
+	}
 
-	d.delay = time.Duration(delay)
+	d := &delayer[Blackboard]{
+		Decorator: base,
+		delay:     delay,
+	}
 	return d
 }
 

--- a/common/decorator/delayer.go
+++ b/common/decorator/delayer.go
@@ -12,12 +12,12 @@ func Delayer[Blackboard any](params core.Params, child core.Node[Blackboard]) co
 	base := core.NewDecorator("Delayer", params, child)
 	d := &delayer[Blackboard]{Decorator: base}
 
-	ms, err := params.GetInt("ms")
+	delay, err := params.GetInt("delay")
 	if err != nil {
 		panic(err)
 	}
 
-	d.delay = time.Duration(ms) * time.Millisecond
+	d.delay = time.Duration(delay)
 	return d
 }
 

--- a/common/decorator/delayer.go
+++ b/common/decorator/delayer.go
@@ -34,9 +34,9 @@ func (d *delayer[Blackboard]) Enter(bb Blackboard) {
 }
 
 // Tick ...
-func (d *delayer[Blackboard]) Tick(bb Blackboard, ctx context.Context, evt core.Event) core.NodeResult {
+func (d *delayer[Blackboard]) Tick(ctx context.Context, bb Blackboard, evt core.Event) core.NodeResult {
 	if time.Since(d.start) > d.delay {
-		return core.Update(d.Child, bb, ctx, evt)
+		return core.Update(ctx, d.Child, bb, evt)
 	}
 	return core.StatusRunning
 }

--- a/common/decorator/inverter.go
+++ b/common/decorator/inverter.go
@@ -21,8 +21,8 @@ type inverter[Blackboard any] struct {
 func (d *inverter[Blackboard]) Enter(bb Blackboard) {}
 
 // Tick ...
-func (d *inverter[Blackboard]) Tick(bb Blackboard, ctx context.Context, evt core.Event) core.NodeResult {
-	switch core.Update(d.Child, bb, ctx, evt) {
+func (d *inverter[Blackboard]) Tick(ctx context.Context, bb Blackboard, evt core.Event) core.NodeResult {
+	switch core.Update(ctx, d.Child, bb, evt) {
 	case core.StatusSuccess:
 		return core.StatusFailure
 	case core.StatusFailure:

--- a/common/decorator/inverter.go
+++ b/common/decorator/inverter.go
@@ -1,6 +1,8 @@
 package decorator
 
 import (
+	"context"
+
 	"github.com/jbcpollak/greenstalk/core"
 )
 
@@ -19,8 +21,8 @@ type inverter[Blackboard any] struct {
 func (d *inverter[Blackboard]) Enter(bb Blackboard) {}
 
 // Tick ...
-func (d *inverter[Blackboard]) Tick(bb Blackboard, evt core.Event) core.NodeResult {
-	switch core.Update(d.Child, bb, evt) {
+func (d *inverter[Blackboard]) Tick(bb Blackboard, ctx context.Context, evt core.Event) core.NodeResult {
+	switch core.Update(d.Child, bb, ctx, evt) {
 	case core.StatusSuccess:
 		return core.StatusFailure
 	case core.StatusFailure:

--- a/common/decorator/repeater.go
+++ b/common/decorator/repeater.go
@@ -2,9 +2,9 @@ package decorator
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/jbcpollak/greenstalk/core"
+	"github.com/rs/zerolog/log"
 )
 
 // Repeater updates its child n times, at which point the repeater
@@ -33,7 +33,7 @@ func (d *repeater[Blackboard]) Enter(bb Blackboard) {
 }
 
 func (d *repeater[Blackboard]) Tick(bb Blackboard, ctx context.Context, evt core.Event) core.NodeResult {
-	fmt.Println("Repeater: Calling child")
+	log.Info().Msg("Repeater: Calling child")
 	status := core.Update(d.Child, bb, ctx, evt)
 
 	if status == core.StatusRunning {

--- a/common/decorator/repeater.go
+++ b/common/decorator/repeater.go
@@ -1,6 +1,7 @@
 package decorator
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/jbcpollak/greenstalk/core"
@@ -31,9 +32,9 @@ func (d *repeater[Blackboard]) Enter(bb Blackboard) {
 	d.i = 0
 }
 
-func (d *repeater[Blackboard]) Tick(bb Blackboard, evt core.Event) core.NodeResult {
+func (d *repeater[Blackboard]) Tick(bb Blackboard, ctx context.Context, evt core.Event) core.NodeResult {
 	fmt.Println("Repeater: Calling child")
-	status := core.Update(d.Child, bb, evt)
+	status := core.Update(d.Child, bb, ctx, evt)
 
 	if status == core.StatusRunning {
 		return core.StatusRunning

--- a/common/decorator/repeater.go
+++ b/common/decorator/repeater.go
@@ -32,9 +32,9 @@ func (d *repeater[Blackboard]) Enter(bb Blackboard) {
 	d.i = 0
 }
 
-func (d *repeater[Blackboard]) Tick(bb Blackboard, ctx context.Context, evt core.Event) core.NodeResult {
+func (d *repeater[Blackboard]) Tick(ctx context.Context, bb Blackboard, evt core.Event) core.NodeResult {
 	log.Info().Msg("Repeater: Calling child")
-	status := core.Update(d.Child, bb, ctx, evt)
+	status := core.Update(ctx, d.Child, bb, evt)
 
 	if status == core.StatusRunning {
 		return core.StatusRunning

--- a/common/decorator/until_failure.go
+++ b/common/decorator/until_failure.go
@@ -1,6 +1,8 @@
 package decorator
 
 import (
+	"context"
+
 	"github.com/jbcpollak/greenstalk/core"
 )
 
@@ -16,8 +18,8 @@ type untilFailure[Blackboard any] struct {
 
 func (d *untilFailure[Blackboard]) Enter(bb Blackboard) {}
 
-func (d *untilFailure[Blackboard]) Tick(bb Blackboard, evt core.Event) core.NodeResult {
-	status := core.Update(d.Child, bb, evt)
+func (d *untilFailure[Blackboard]) Tick(bb Blackboard, ctx context.Context, evt core.Event) core.NodeResult {
+	status := core.Update(d.Child, bb, ctx, evt)
 	if status == core.StatusFailure {
 		return core.StatusSuccess
 	}

--- a/common/decorator/until_failure.go
+++ b/common/decorator/until_failure.go
@@ -18,8 +18,8 @@ type untilFailure[Blackboard any] struct {
 
 func (d *untilFailure[Blackboard]) Enter(bb Blackboard) {}
 
-func (d *untilFailure[Blackboard]) Tick(bb Blackboard, ctx context.Context, evt core.Event) core.NodeResult {
-	status := core.Update(d.Child, bb, ctx, evt)
+func (d *untilFailure[Blackboard]) Tick(ctx context.Context, bb Blackboard, evt core.Event) core.NodeResult {
+	status := core.Update(ctx, d.Child, bb, evt)
 	if status == core.StatusFailure {
 		return core.StatusSuccess
 	}

--- a/common/decorator/until_success.go
+++ b/common/decorator/until_success.go
@@ -1,6 +1,8 @@
 package decorator
 
 import (
+	"context"
+
 	"github.com/jbcpollak/greenstalk/core"
 )
 
@@ -16,8 +18,8 @@ type untilSuccess[Blackboard any] struct {
 
 func (d *untilSuccess[Blackboard]) Enter(bb Blackboard) {}
 
-func (d *untilSuccess[Blackboard]) Tick(bb Blackboard, evt core.Event) core.NodeResult {
-	status := core.Update(d.Child, bb, evt)
+func (d *untilSuccess[Blackboard]) Tick(bb Blackboard, ctx context.Context, evt core.Event) core.NodeResult {
+	status := core.Update(d.Child, bb, ctx, evt)
 	if status == core.StatusSuccess {
 		return core.StatusSuccess
 	}

--- a/common/decorator/until_success.go
+++ b/common/decorator/until_success.go
@@ -18,8 +18,8 @@ type untilSuccess[Blackboard any] struct {
 
 func (d *untilSuccess[Blackboard]) Enter(bb Blackboard) {}
 
-func (d *untilSuccess[Blackboard]) Tick(bb Blackboard, ctx context.Context, evt core.Event) core.NodeResult {
-	status := core.Update(d.Child, bb, ctx, evt)
+func (d *untilSuccess[Blackboard]) Tick(ctx context.Context, bb Blackboard, evt core.Event) core.NodeResult {
+	status := core.Update(ctx, d.Child, bb, evt)
 	if status == core.StatusSuccess {
 		return core.StatusSuccess
 	}

--- a/common/decorator/while.go
+++ b/common/decorator/while.go
@@ -43,10 +43,10 @@ func (d *while[Blackboard]) Enter(bb Blackboard) {
 
 }
 
-func (d *while[Blackboard]) Tick(bb Blackboard, ctx context.Context, evt core.Event) core.NodeResult {
+func (d *while[Blackboard]) Tick(ctx context.Context, bb Blackboard, evt core.Event) core.NodeResult {
 
 	// check the condition
-	status := core.Update(d.Child, bb, ctx, evt)
+	status := core.Update(ctx, d.Child, bb, evt)
 
 	switch status {
 	case core.StatusRunning:
@@ -58,7 +58,7 @@ func (d *while[Blackboard]) Tick(bb Blackboard, ctx context.Context, evt core.Ev
 	}
 
 	// here condition is successful
-	actionStatus := core.Update(d.action, bb, ctx, evt)
+	actionStatus := core.Update(ctx, d.action, bb, evt)
 
 	return actionStatus
 

--- a/common/decorator/while.go
+++ b/common/decorator/while.go
@@ -1,6 +1,10 @@
 package decorator
 
-import "github.com/jbcpollak/greenstalk/core"
+import (
+	"context"
+
+	"github.com/jbcpollak/greenstalk/core"
+)
 
 // While node repeats the conditions and runs the action if the condition succeeds.
 // The action is started after the first success of the condition.
@@ -39,10 +43,10 @@ func (d *while[Blackboard]) Enter(bb Blackboard) {
 
 }
 
-func (d *while[Blackboard]) Tick(bb Blackboard, evt core.Event) core.NodeResult {
+func (d *while[Blackboard]) Tick(bb Blackboard, ctx context.Context, evt core.Event) core.NodeResult {
 
 	// check the condition
-	status := core.Update(d.Child, bb, evt)
+	status := core.Update(d.Child, bb, ctx, evt)
 
 	switch status {
 	case core.StatusRunning:
@@ -54,7 +58,7 @@ func (d *while[Blackboard]) Tick(bb Blackboard, evt core.Event) core.NodeResult 
 	}
 
 	// here condition is successful
-	actionStatus := core.Update(d.action, bb, evt)
+	actionStatus := core.Update(d.action, bb, ctx, evt)
 
 	return actionStatus
 

--- a/core/node.go
+++ b/core/node.go
@@ -42,6 +42,11 @@ func newBaseNode(category Category, name string) BaseNode {
 }
 
 // Status returns the status of this node.
+func (n *BaseNode) Name() string {
+	return n.name
+}
+
+// Status returns the status of this node.
 func (n *BaseNode) Status() Status {
 	return n.status
 }

--- a/core/node.go
+++ b/core/node.go
@@ -41,7 +41,7 @@ type Node[Blackboard any] interface {
 
 	// Must be implemented by the custom node.
 	Enter(Blackboard)
-	Tick(Blackboard, context.Context, Event) NodeResult
+	Tick(context.Context, Blackboard, Event) NodeResult
 	Leave(Blackboard)
 }
 

--- a/core/node.go
+++ b/core/node.go
@@ -1,5 +1,7 @@
 package core
 
+import "context"
+
 type Event any
 
 // Preliminary interface to work around intermediate types like
@@ -23,7 +25,7 @@ type Node[Blackboard any] interface {
 
 	// Must be implemented by the custom node.
 	Enter(Blackboard)
-	Tick(Blackboard, Event) NodeResult
+	Tick(Blackboard, context.Context, Event) NodeResult
 	Leave(Blackboard)
 }
 

--- a/core/node.go
+++ b/core/node.go
@@ -1,8 +1,23 @@
 package core
 
-import "context"
+import (
+	"context"
 
-type Event any
+	"github.com/google/uuid"
+)
+
+type Event interface {
+	// UUID of the node that generated the event
+	// Use uuid.Nil for events that are applicable to many nodes
+	TargetNodeId() uuid.UUID
+}
+
+type DefaultEvent struct {
+}
+
+func (e DefaultEvent) TargetNodeId() uuid.UUID {
+	return uuid.Nil
+}
 
 // Preliminary interface to work around intermediate types like
 // composite, decorator, etc not inplementing Enter/Tick/Leave
@@ -11,6 +26,7 @@ type Walkable[Blackboard any] interface {
 	// Composite, Decorator or Leaf node in the custom node.
 	Status() Status
 	SetStatus(Status)
+	Id() uuid.UUID
 	Category() Category
 	String() string
 
@@ -32,13 +48,19 @@ type Node[Blackboard any] interface {
 // BaseNode contains properties shared by all categories of node.
 // Do not use this type directly.
 type BaseNode struct {
+	id       uuid.UUID
 	category Category
 	name     string
 	status   Status
 }
 
 func newBaseNode(category Category, name string) BaseNode {
-	return BaseNode{category: category, name: name}
+	return BaseNode{id: uuid.New(), category: category, name: name}
+}
+
+// Status returns the status of this node.
+func (n *BaseNode) Id() uuid.UUID {
+	return n.id
 }
 
 // Status returns the status of this node.

--- a/core/types.go
+++ b/core/types.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"context"
 	"fmt"
 )
 
@@ -35,7 +36,7 @@ const (
 func (s Status) Status() Status { return s }
 
 type EnqueueFn func(Event) error
-type NodeAsyncRunning func(enqueue EnqueueFn) error
+type NodeAsyncRunning func(ctx context.Context, enqueue EnqueueFn) error
 
 func (NodeAsyncRunning) Status() Status { return StatusRunning }
 
@@ -53,6 +54,14 @@ type (
 	// Returns is just a type alias for Params.
 	Returns = Params
 )
+
+func (p Params) Get(key string) (any, error) {
+	val, ok := p[key]
+	if !ok {
+		return 0, ErrParamNotFound(key)
+	}
+	return val, nil
+}
 
 func (p Params) GetInt(key string) (int, error) {
 	val, ok := p[key]

--- a/core/types.go
+++ b/core/types.go
@@ -34,7 +34,8 @@ const (
 
 func (s Status) Status() Status { return s }
 
-type NodeAsyncRunning func(enqueue func(Event) error) error
+type EnqueueFn func(Event) error
+type NodeAsyncRunning func(enqueue EnqueueFn) error
 
 func (NodeAsyncRunning) Status() Status { return StatusRunning }
 

--- a/core/update.go
+++ b/core/update.go
@@ -1,14 +1,16 @@
 package core
 
+import "context"
+
 // Update updates a node by calling its Enter method if it is not running,
 // then its Tick method, and finally Leave if it is not still running.
-func Update[Blackboard any](node Node[Blackboard], bb Blackboard, evt Event) NodeResult {
+func Update[Blackboard any](node Node[Blackboard], bb Blackboard, ctx context.Context, evt Event) NodeResult {
 
 	if node.Status() != StatusRunning {
 		node.Enter(bb)
 	}
 
-	result := node.Tick(bb, evt)
+	result := node.Tick(bb, ctx, evt)
 
 	status := result.Status()
 	node.SetStatus(status)

--- a/core/update.go
+++ b/core/update.go
@@ -6,12 +6,13 @@ import "context"
 // then its Tick method, and finally Leave if it is not still running.
 func Update[Blackboard any](node Node[Blackboard], bb Blackboard, ctx context.Context, evt Event) NodeResult {
 
+	// var result NodeResult
 	if node.Status() != StatusRunning {
 		node.Enter(bb)
+		// } else {
 	}
 
 	result := node.Tick(bb, ctx, evt)
-
 	status := result.Status()
 	node.SetStatus(status)
 

--- a/core/update.go
+++ b/core/update.go
@@ -4,7 +4,7 @@ import "context"
 
 // Update updates a node by calling its Enter method if it is not running,
 // then its Tick method, and finally Leave if it is not still running.
-func Update[Blackboard any](node Node[Blackboard], bb Blackboard, ctx context.Context, evt Event) NodeResult {
+func Update[Blackboard any](ctx context.Context, node Node[Blackboard], bb Blackboard, evt Event) NodeResult {
 
 	// var result NodeResult
 	if node.Status() != StatusRunning {
@@ -12,7 +12,7 @@ func Update[Blackboard any](node Node[Blackboard], bb Blackboard, ctx context.Co
 		// } else {
 	}
 
-	result := node.Tick(bb, ctx, evt)
+	result := node.Tick(ctx, bb, evt)
 	status := result.Status()
 	node.SetStatus(status)
 

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/fatih/color v1.7.0
 	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.32.0
+	github.com/google/uuid v1.6.0 // direct
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSV
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=

--- a/greenstalk.go
+++ b/greenstalk.go
@@ -7,6 +7,7 @@ import (
 	"github.com/jbcpollak/greenstalk/core"
 	"github.com/jbcpollak/greenstalk/internal"
 	"github.com/jbcpollak/greenstalk/util"
+	"github.com/rs/zerolog/log"
 )
 
 // BehaviorTree ...
@@ -50,7 +51,7 @@ func (bt *BehaviorTree[Blackboard]) Update(evt core.Event) core.Status {
 		// whatever
 	case core.StatusRunning:
 		if asyncRunning, ok := result.(core.NodeAsyncRunning); ok {
-			go asyncRunning(func(evt core.Event) error {
+			go asyncRunning(bt.ctx, func(evt core.Event) error {
 				bt.events <- evt
 				return nil
 			})
@@ -73,10 +74,9 @@ func (bt *BehaviorTree[Blackboard]) EventLoop(evt core.Event) {
 	bt.events <- evt
 
 	for evt := range bt.events {
-		fmt.Printf("Event: %v\n", evt)
+		log.Info().Msgf("Event: %v", evt)
 		bt.Update(evt)
 		util.PrintTreeInColor(bt.Root)
-		fmt.Println()
 	}
 }
 

--- a/greenstalk.go
+++ b/greenstalk.go
@@ -39,7 +39,7 @@ func NewBehaviorTree[Blackboard any](ctx context.Context, root core.Node[Blackbo
 
 // Update propagates an update call down the behavior tree.
 func (bt *BehaviorTree[Blackboard]) Update(evt core.Event) core.Status {
-	result := core.Update(bt.Root, bt.Blackboard, bt.ctx, evt)
+	result := core.Update(bt.ctx, bt.Root, bt.Blackboard, evt)
 
 	status := result.Status()
 	switch status {

--- a/greenstalk.go
+++ b/greenstalk.go
@@ -18,8 +18,6 @@ type BehaviorTree[Blackboard any] struct {
 	events     chan core.Event
 }
 
-// NewBehaviorTree returns a new BehaviorTree. A data Blackboard
-// to be propagated down the tree each tick is created.
 func NewBehaviorTree[Blackboard any](ctx context.Context, root core.Node[Blackboard], bb Blackboard) (*BehaviorTree[Blackboard], error) {
 	var eb internal.ErrorBuilder
 	eb.SetMessage("NewBehaviorTree")

--- a/greenstalk_test.go
+++ b/greenstalk_test.go
@@ -57,7 +57,7 @@ func (a *counter) Enter(bb TestBlackboard) {}
 // Tick ...
 var countChan = make(chan uint, 0)
 
-func (a *counter) Tick(bb TestBlackboard, ctx context.Context, evt core.Event) core.NodeResult {
+func (a *counter) Tick(ctx context.Context, bb TestBlackboard, evt core.Event) core.NodeResult {
 	log.Info().Msgf("%s: Incrementing count", a.Name())
 	bb.count++
 	countChan <- bb.count

--- a/greenstalk_test.go
+++ b/greenstalk_test.go
@@ -17,19 +17,6 @@ import (
 	. "github.com/jbcpollak/greenstalk/common/decorator"
 )
 
-// var delayingRoot = Repeater(core.Params{"n": 2},
-// 	PersistentSequence(
-// 		Delayer(core.Params{"ms": 700},
-// 			Succeed(nil, nil),
-// 		),
-// 		Delayer(core.Params{"ms": 400},
-// 			Inverter(nil,
-// 				Fail(nil, nil),
-// 			),
-// 		),
-// 	),
-// )
-
 type TestBlackboard struct {
 	id    int
 	count uint

--- a/util/print_color.go
+++ b/util/print_color.go
@@ -34,6 +34,7 @@ func appendNode[Blackboard any](node core.Walkable[Blackboard], level int, b *st
 // Red = Failure, Yellow = Running, Green = Success, Magenta = Invalid.
 func PrintTreeInColor[Blackboard any](node core.Node[Blackboard]) {
 	node.Walk(printInColor, 0)
+	fmt.Println()
 }
 
 func printInColor[Blackboard any](node core.Walkable[Blackboard], level int) {


### PR DESCRIPTION
This PR allows async nodes to be canceled and introduces a (messy) unit test to verify this works correctly.

Some other refactoring to support other features and more idiomatic use as well