### PR TITLE
feat: added 'name prefix' field to all nodes, and function to fetch it

### DIFF
--- a/common/decorator/dynamic_decorator.go
+++ b/common/decorator/dynamic_decorator.go
@@ -20,6 +20,7 @@ func (d *dynamicDecorator[Blackboard]) Activate(ctx context.Context, bb Blackboa
 	if err != nil {
 		return core.ErrorResult(err)
 	}
+	child.SetNamePrefix(d.FullName())
 	d.Child = child
 
 	return d.Tick(ctx, bb, evt)

--- a/core/composite.go
+++ b/core/composite.go
@@ -33,7 +33,7 @@ func (c *Composite[Blackboard, P]) String() string {
 }
 
 func (c *Composite[Blackboard, P]) SetNamePrefix(namePrefix string) {
-	c.BaseNode.SetNamePrefix(namePrefix + c.Name())
+	c.BaseNode.SetNamePrefix(namePrefix)
 	for _, child := range c.Children {
 		child.SetNamePrefix(c.FullName())
 	}

--- a/core/composite.go
+++ b/core/composite.go
@@ -33,7 +33,7 @@ func (c *Composite[Blackboard, P]) String() string {
 }
 
 func (c *Composite[Blackboard, P]) SetNamePrefix(namePrefix string) {
-	c.namePrefix = namePrefix + c.Name() + NAME_PREFIX_SEPARATOR
+	c.BaseNode.SetNamePrefix(namePrefix + c.Name())
 	for _, child := range c.Children {
 		child.SetNamePrefix(c.FullName())
 	}

--- a/core/composite.go
+++ b/core/composite.go
@@ -11,6 +11,9 @@ type Composite[Blackboard any, P Params] struct {
 
 // NewComposite creates a new composite base node.
 func NewComposite[Blackboard any, P Params](params P, children []Node[Blackboard]) Composite[Blackboard, P] {
+	for _, child := range children {
+		child.SetNamePrefix(params.Name())
+	}
 	return Composite[Blackboard, P]{
 		BaseNode: newBaseNode(CategoryComposite, params),
 		Children: children,
@@ -27,4 +30,11 @@ func (c *Composite[Blackboard, P]) Walk(walkFn WalkFunc[Blackboard], level int) 
 // String returns a string representation of the composite node.
 func (c *Composite[Blackboard, P]) String() string {
 	return "+ " + c.Params.Name()
+}
+
+func (c *Composite[Blackboard, P]) SetNamePrefix(namePrefix string) {
+	c.namePrefix = namePrefix + c.Name() + NAME_PREFIX_SEPARATOR
+	for _, child := range c.Children {
+		child.SetNamePrefix(c.FullName())
+	}
 }

--- a/core/decorator.go
+++ b/core/decorator.go
@@ -35,6 +35,6 @@ func (d *Decorator[Blackboard, P]) String() string {
 }
 
 func (d *Decorator[Blackboard, P]) SetNamePrefix(namePrefix string) {
-	d.BaseNode.SetNamePrefix(namePrefix + d.Name())
+	d.BaseNode.SetNamePrefix(namePrefix)
 	d.Child.SetNamePrefix(d.FullName())
 }

--- a/core/decorator.go
+++ b/core/decorator.go
@@ -35,6 +35,6 @@ func (d *Decorator[Blackboard, P]) String() string {
 }
 
 func (d *Decorator[Blackboard, P]) SetNamePrefix(namePrefix string) {
-	d.namePrefix = namePrefix + d.Name() + NAME_PREFIX_SEPARATOR
+	d.BaseNode.SetNamePrefix(namePrefix + d.Name())
 	d.Child.SetNamePrefix(d.FullName())
 }

--- a/core/decorator.go
+++ b/core/decorator.go
@@ -17,6 +17,7 @@ type Decorator[Blackboard any, P Params] struct {
 
 // NewDecorator creates a new decorator base node.
 func NewDecorator[Blackboard any, P Params](params P, child Node[Blackboard]) Decorator[Blackboard, P] {
+	child.SetNamePrefix(params.Name())
 	return Decorator[Blackboard, P]{
 		BaseNode: newBaseNode(CategoryDecorator, params),
 		Child:    child,
@@ -31,4 +32,9 @@ func (c *Decorator[Blackboard, P]) Walk(walkFn WalkFunc[Blackboard], level int) 
 // String returns a string representation of the decorator node.
 func (d *Decorator[Blackboard, P]) String() string {
 	return fmt.Sprintf("* %s (%v)", d.Params.Name(), d.Params)
+}
+
+func (d *Decorator[Blackboard, P]) SetNamePrefix(namePrefix string) {
+	d.namePrefix = namePrefix + d.Name() + NAME_PREFIX_SEPARATOR
+	d.Child.SetNamePrefix(d.FullName())
 }

--- a/core/dynamic_decorator.go
+++ b/core/dynamic_decorator.go
@@ -27,7 +27,7 @@ func (d *DynamicDecorator[Blackboard, P]) String() string {
 }
 
 func (d *DynamicDecorator[Blackboard, P]) SetNamePrefix(namePrefix string) {
-	d.BaseNode.SetNamePrefix(namePrefix + d.Name())
+	d.BaseNode.SetNamePrefix(namePrefix)
 	if d.Child != nil {
 		d.Child.SetNamePrefix(d.FullName())
 	}

--- a/core/dynamic_decorator.go
+++ b/core/dynamic_decorator.go
@@ -25,3 +25,10 @@ func (c *DynamicDecorator[Blackboard, P]) Walk(walkFn WalkFunc[Blackboard], leve
 func (d *DynamicDecorator[Blackboard, P]) String() string {
 	return fmt.Sprintf("*d %s (%v)", d.Params.Name(), d.Params)
 }
+
+func (d *DynamicDecorator[Blackboard, P]) SetNamePrefix(namePrefix string) {
+	d.namePrefix = namePrefix + d.Name() + NAME_PREFIX_SEPARATOR
+	if d.Child != nil {
+		d.Child.SetNamePrefix(d.FullName())
+	}
+}

--- a/core/dynamic_decorator.go
+++ b/core/dynamic_decorator.go
@@ -27,7 +27,7 @@ func (d *DynamicDecorator[Blackboard, P]) String() string {
 }
 
 func (d *DynamicDecorator[Blackboard, P]) SetNamePrefix(namePrefix string) {
-	d.namePrefix = namePrefix + d.Name() + NAME_PREFIX_SEPARATOR
+	d.BaseNode.SetNamePrefix(namePrefix + d.Name())
 	if d.Child != nil {
 		d.Child.SetNamePrefix(d.FullName())
 	}

--- a/core/node.go
+++ b/core/node.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/google/uuid"
-	"github.com/letsencrypt/boulder/errors"
 )
 
 const NAME_PREFIX_SEPARATOR = "."
@@ -90,7 +89,7 @@ type BaseNode[P Params] struct {
 
 func newBaseNode[P Params](category Category, params P) BaseNode[P] {
 	if strings.Contains(params.Name(), NAME_PREFIX_SEPARATOR) {
-		err := errors.New(fmt.Sprintf("Node '%s' name may not contain node name separator string '%s'", params.Name(), NAME_PREFIX_SEPARATOR))
+		err := fmt.Errorf("Node '%s' name may not contain node name separator string '%s'", params.Name(), NAME_PREFIX_SEPARATOR)
 		panic(err)
 	}
 	return BaseNode[P]{

--- a/core/node.go
+++ b/core/node.go
@@ -51,7 +51,6 @@ type Walkable[Blackboard any] interface {
 	Id() uuid.UUID
 	Name() string
 	FullName() string
-	SetNamePrefix(string)
 	Category() Category
 	String() string
 
@@ -69,6 +68,7 @@ type Node[Blackboard any] interface {
 	Activate(context.Context, Blackboard, Event) ResultDetails
 	Tick(context.Context, Blackboard, Event) ResultDetails
 	Leave(Blackboard) error
+	SetNamePrefix(string)
 }
 
 type Params interface {

--- a/core/node.go
+++ b/core/node.go
@@ -6,6 +6,8 @@ import (
 	"github.com/google/uuid"
 )
 
+const NAME_PREFIX_SEPARATOR = "."
+
 type Event interface {
 	// UUID of the node that generated the event
 	// Use uuid.Nil for events that are applicable to many nodes
@@ -48,6 +50,8 @@ type Walkable[Blackboard any] interface {
 	SetResult(ResultDetails)
 	Id() uuid.UUID
 	Name() string
+	FullName() string
+	SetNamePrefix(string)
 	Category() Category
 	String() string
 
@@ -74,18 +78,20 @@ type Params interface {
 // BaseNode contains properties shared by all categories of node.
 // Do not use this type directly.
 type BaseNode[P Params] struct {
-	id       uuid.UUID
-	category Category
-	result   ResultDetails
-	Params   P
+	id         uuid.UUID
+	category   Category
+	result     ResultDetails
+	Params     P
+	namePrefix string
 }
 
 func newBaseNode[P Params](category Category, params P) BaseNode[P] {
 	return BaseNode[P]{
-		id:       uuid.New(),
-		category: category,
-		result:   InvalidResult(),
-		Params:   params,
+		id:         uuid.New(),
+		category:   category,
+		result:     InvalidResult(),
+		Params:     params,
+		namePrefix: "",
 	}
 }
 
@@ -112,4 +118,12 @@ func (n *BaseNode[P]) SetResult(result ResultDetails) {
 // GetCategory returns the category of this node.
 func (n *BaseNode[P]) Category() Category {
 	return n.category
+}
+
+func (n *BaseNode[P]) FullName() string {
+	return n.namePrefix + n.Name()
+}
+
+func (n *BaseNode[P]) SetNamePrefix(name string) {
+	n.namePrefix = name + NAME_PREFIX_SEPARATOR
 }

--- a/core/node.go
+++ b/core/node.go
@@ -2,8 +2,11 @@ package core
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
 	"github.com/google/uuid"
+	"github.com/letsencrypt/boulder/errors"
 )
 
 const NAME_PREFIX_SEPARATOR = "."
@@ -86,6 +89,10 @@ type BaseNode[P Params] struct {
 }
 
 func newBaseNode[P Params](category Category, params P) BaseNode[P] {
+	if strings.Contains(params.Name(), NAME_PREFIX_SEPARATOR) {
+		err := errors.New(fmt.Sprintf("Node '%s' name may not contain node name separator string '%s'", params.Name(), NAME_PREFIX_SEPARATOR))
+		panic(err)
+	}
 	return BaseNode[P]{
 		id:         uuid.New(),
 		category:   category,


### PR DESCRIPTION
Added a 'name prefix' for all nodes, and a FullName() method that fetches the prefix plus the node name.

Example output when jammed into ros2 messages:
```
node_uuid: 32dcdefc-cc09-4b37-aef0-dda6b64e3d0c
node_full_path: Sequence.bayconStartup
transition_time:
  sec: 1751057403
  nanosec: 721709530
transition_status: 1
---
node_uuid: 7cbd264c-f06d-4005-b16c-79757ce70a7b
node_full_path: Sequence.Sequence
transition_time:
  sec: 1751057403
  nanosec: 721774851
transition_status: 3
---
node_uuid: 3271f2a4-2864-4e1b-94a4-acd51b9c6131
node_full_path: Sequence.Sequence.stopAndDisengageSpinner
transition_time:
  sec: 1751057403
  nanosec: 721788942
transition_status: 3
---
node_uuid: 7cbd264c-f06d-4005-b16c-79757ce70a7b
node_full_path: Sequence.Sequence
transition_time:
  sec: 1751057408
  nanosec: 746046361
transition_status: 1
---
node_uuid: 3271f2a4-2864-4e1b-94a4-acd51b9c6131
node_full_path: Sequence.Sequence.stopAndDisengageSpinner
transition_time:
  sec: 1751057408
  nanosec: 746154888
transition_status: 1
---
```