### PR TITLE
feat: better close signature for With node BREAKING CHANGE

### DIFF
--- a/common/decorator/with.go
+++ b/common/decorator/with.go
@@ -6,11 +6,11 @@ import (
 	"github.com/jbcpollak/greenstalk/core"
 )
 
-func WithNamed[Blackboard any](name string, createCloseable func() (func() error, error), child core.Node[Blackboard]) core.Node[Blackboard] {
+func WithNamed[Blackboard any](name string, createCloseable func() (closeFn func() error, err error), child core.Node[Blackboard]) core.Node[Blackboard] {
 	base := core.NewDecorator(core.BaseParams(name), child)
 	return &with[Blackboard]{Decorator: base, createCloseable: createCloseable}
 }
-func With[Blackboard any](createCloseable func() (func() error, error), child core.Node[Blackboard]) core.Node[Blackboard] {
+func With[Blackboard any](createCloseable func() (closeFn func() error, err error), child core.Node[Blackboard]) core.Node[Blackboard] {
 	return WithNamed("With", createCloseable, child)
 }
 

--- a/common/decorator/with.go
+++ b/common/decorator/with.go
@@ -2,23 +2,22 @@ package decorator
 
 import (
 	"context"
-	"io"
 
 	"github.com/jbcpollak/greenstalk/core"
 )
 
-func WithNamed[Blackboard any](name string, createCloseable func() (io.Closer, error), child core.Node[Blackboard]) core.Node[Blackboard] {
+func WithNamed[Blackboard any](name string, createCloseable func() (func() error, error), child core.Node[Blackboard]) core.Node[Blackboard] {
 	base := core.NewDecorator(core.BaseParams(name), child)
 	return &with[Blackboard]{Decorator: base, createCloseable: createCloseable}
 }
-func With[Blackboard any](createCloseable func() (io.Closer, error), child core.Node[Blackboard]) core.Node[Blackboard] {
+func With[Blackboard any](createCloseable func() (func() error, error), child core.Node[Blackboard]) core.Node[Blackboard] {
 	return WithNamed("With", createCloseable, child)
 }
 
 type with[Blackboard any] struct {
 	core.Decorator[Blackboard, core.BaseParams]
-	createCloseable func() (io.Closer, error)
-	closeable       io.Closer
+	createCloseable func() (func() error, error)
+	closeFn         func() error
 }
 
 func (d *with[Blackboard]) Activate(ctx context.Context, bb Blackboard, evt core.Event) core.ResultDetails {
@@ -26,7 +25,7 @@ func (d *with[Blackboard]) Activate(ctx context.Context, bb Blackboard, evt core
 	if err != nil {
 		return core.ErrorResult(err)
 	} else {
-		d.closeable = closeable
+		d.closeFn = closeable
 	}
 	return d.Tick(ctx, bb, evt)
 }
@@ -38,5 +37,5 @@ func (d *with[Blackboard]) Tick(ctx context.Context, bb Blackboard, evt core.Eve
 
 // Leave ...
 func (d *with[Blackboard]) Leave(bb Blackboard) error {
-	return d.closeable.Close()
+	return d.closeFn()
 }

--- a/common/decorator/with_test.go
+++ b/common/decorator/with_test.go
@@ -187,17 +187,15 @@ func TestWithInitError(t *testing.T) {
 
 	sigChan := make(chan bool)
 
-	childCalled := new(bool)
-	*childCalled = false
+	childCalled := false
 	child := action.FunctionAction[core.EmptyBlackboard](action.FunctionActionParams{
 		Func: func() core.ResultDetails {
-			*childCalled = true
+			childCalled = true
 			return core.SuccessResult()
 		},
 	})
 
-	closeCalled := new(bool)
-	*closeCalled = false
+	closeCalled := false
 
 	with := With(func() (func() error, error) {
 		return nil, fmt.Errorf("This is an error")
@@ -252,11 +250,11 @@ func TestWithInitError(t *testing.T) {
 		t.Errorf("Unexpectedly got %v", status)
 	}
 
-	if *childCalled {
+	if childCalled {
 		t.Errorf("Child was unexpectedly called")
 	}
 
-	if *closeCalled {
+	if closeCalled {
 		t.Errorf("Close was unexpectedly called")
 	}
 }

--- a/common/decorator/with_test.go
+++ b/common/decorator/with_test.go
@@ -38,8 +38,6 @@ func TestWith(t *testing.T) {
 	with := With(func() (func() error, error) {
 		return closeFn, nil
 	}, child)
-	// TODO: testCloser and the whole closeCalled thing above just creates a struct with an attached method
-	// Is there a more succinct way to write this?
 
 	params := action.SignallerParams[bool]{
 		BaseParams: "Signaller",
@@ -121,8 +119,6 @@ func TestWithCloserError(t *testing.T) {
 	with := With(func() (func() error, error) {
 		return closeFn, nil
 	}, child)
-	// TODO: testCloser and the whole closeCalled thing above just creates a struct with an attached method
-	// Is there a more succinct way to write this?
 
 	params := action.SignallerParams[bool]{
 		BaseParams: "Signaller",
@@ -200,8 +196,6 @@ func TestWithInitError(t *testing.T) {
 	with := With(func() (func() error, error) {
 		return nil, fmt.Errorf("This is an error")
 	}, child)
-	// TODO: testCloser and the whole closeCalled thing above just creates a struct with an attached method
-	// Is there a more succinct way to write this?
 
 	params := action.SignallerParams[bool]{
 		BaseParams: "Signaller",


### PR DESCRIPTION
With node now uses a function to generate closeable entities along with a close function, rather than a struct that implements io.Closer